### PR TITLE
Fix wrong pipx command to run with python 3.12 interpreter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ uvx --python 3.12 textual-demo
 If you have [pipx](https://pipx.pypa.io/stable/) installed:
 
 ```
-pipx run --python 3.12 textual-demo
+pipx run --python python3.12 textual-demo
 ```
 
 <img width="1382" alt="Screenshot 2024-11-24 at 12 32 53" src="https://github.com/user-attachments/assets/dc17d2c5-4608-4910-872a-08fe6b2fe70c">


### PR DESCRIPTION
I just tried out the textual demo running pipx and I got hit by an error:
```bash
$ pipx run --python 3.12 textual-demo
Traceback (most recent call last):
  File "/home/fjm/.local/bin/pipx", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/fjm/.share/pipx/lib64/python3.12/site-packages/pipx/main.py", line 885, in cli
    return run_pipx_command(parsed_pipx_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fjm/.share/pipx/lib64/python3.12/site-packages/pipx/main.py", line 197, in run_pipx_command
    commands.run(
  File "/home/fjm/.share/pipx/lib64/python3.12/site-packages/pipx/commands/run.py", line 200, in run
    run_package(
  File "/home/fjm/.share/pipx/lib64/python3.12/site-packages/pipx/commands/run.py", line 157, in run_package
    _download_and_run(
  File "/home/fjm/.share/pipx/lib64/python3.12/site-packages/pipx/commands/run.py", line 234, in _download_and_run
    venv.create_venv(venv_args, pip_args, override_shared)
  File "/home/fjm/.share/pipx/lib64/python3.12/site-packages/pipx/venv.py", line 160, in create_venv
    venv_process = run_subprocess(cmd + venv_args + [str(self.root)])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fjm/.share/pipx/lib64/python3.12/site-packages/pipx/util.py", line 174, in run_subprocess
    completed_process = subprocess.run(
                        ^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '3.12'
```

But changing it to 
```bash
pipx run --python python3.12 textual-demo
```

worked just fine.